### PR TITLE
Adds server side db and s3 asset support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 app/*
-materia-thumbnail-generator/*
 venv/
 *.pyc
 .DS_Store
+materia-server-client-assets/*

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -16,7 +16,6 @@ http {
 
     access_log  /var/log/nginx/access.log  main;
 
-    sendfile            on;
     tcp_nopush          on;
     tcp_nodelay         on;
     keepalive_timeout   65;
@@ -55,6 +54,8 @@ http {
     # Main Application Server
     server {
         listen *:80;
+        listen *:443;
+        listen *:8008;
         server_name default;
 
         error_page 404 = @handler;
@@ -71,10 +72,6 @@ http {
         # Force IE to be in standards compliant mode
         add_header X-UA-Compatible 'IE=edge';
         add_header P3P 'CP="Materia does not have a P3P policy. View our privacy policy here: http://www.ucf.edu/policy/"';
-
-        # USE THIS IN VAGRANT BECAUSE OF VIRTUAL BOX BUG
-        # APPENDS GARBAGE TO FILES SOME TIMES OR DOESNT UPDATE THEM
-        sendfile off;
 
         client_max_body_size 50M;
 
@@ -100,14 +97,6 @@ http {
             access_log off;
             return 200 'OH YEAAA';
             add_header Content-Type text/plain;
-            break;
-        }
-
-        # x accell for media files
-        location ^~ /protected_media/ {
-            internal;
-            alias /usr/share/media/; # mounted from app/fuel/packages/materia/media/
-            expires max;
             break;
         }
 
@@ -147,33 +136,6 @@ http {
         # deny direct access to any php files
         location ~ \.php$ {
             deny all;
-        }
-    }
-
-
-    # Static Asset Server on a different domain or port
-    server {
-        listen *:8008;
-        server_name static;
-
-        server_tokens off;
-
-        access_log off;
-        error_log /var/log/nginx/error.log;
-
-        sendfile off;
-
-        root /var/www/html/public/;
-        index index.html index.htm;
-
-        add_header X-UA-Compatible 'IE=edge';
-        add_header P3P 'CP="Materia does not have a P3P policy. View our privacy policy here: http://www.ucf.edu/policy/"';
-
-        log_not_found off;
-        expires max;
-
-        location ~ (\.(php|zip|git)$) {
-            return 404;
         }
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,10 +57,7 @@ services:
     ports:
       - "10001:10001"
     volumes:
-      - "./materia-thumbnail-generator:/materia-thumbnail-generator"
       - uploaded_media:/s3mnt/fakes3_root/fakes3_uploads/media/
-    command:
-      bash -c "sh /materia-thumbnail-generator/setup_fakes3.sh"
 
 volumes:
   # static_files: {} # compiled js/css and uploaded widgets

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     links:
       - mysql
       - memcached
+      - fakes3
 
   mysql:
     image: mysql:5.7.18

--- a/dockerfiles/materia-fakes3
+++ b/dockerfiles/materia-fakes3
@@ -1,29 +1,10 @@
-FROM amazonlinux:2018.03
+FROM ruby:2.5-alpine
 
-RUN yum -y install \
-  ruby \
-  build-base \
-  git \
-  libjpeg-turbo-dev \
-  python \
-  python-dev \
-  python27-pip \
-  bash
-
-# fakes3 requires setup because this is not the public build
-RUN git clone https://github.com/ucfcdl/fake-s3.git /tmp/fake-s3
-
-WORKDIR /tmp/fake-s3
-RUN gem build fakes3.gemspec
-RUN gem install fakes3-1.2.0.gem
-WORKDIR /
-
-# These python dependencies are only used for this container, and will not be shipped with the Lambda function
-RUN pip install watchdog
-RUN pip install requests
-RUN pip install boto3 # lambda supports this library
+RUN gem install fakes3 -v 2.0.0
 
 # create directory for s3 to hold uploads
 RUN mkdir -p /s3mnt
 
 EXPOSE 10001
+
+CMD ["fakes3", "-r", "/s3mnt/fakes3_root", "-p", "10001"]

--- a/dockerfiles/materia-fakes3
+++ b/dockerfiles/materia-fakes3
@@ -7,4 +7,4 @@ RUN mkdir -p /s3mnt
 
 EXPOSE 10001
 
-CMD ["fakes3", "-r", "/s3mnt/fakes3_root", "-p", "10001"]
+CMD ["fakes3", "-r", "/s3mnt/fakes3_root", "-p", "10001", "--license", "MIT"]

--- a/run_docker_build_fakes3.sh
+++ b/run_docker_build_fakes3.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#######################################################
+# ABOUT THIS SCRIPT
+#
+# Builds a new materia-node container using a dockerfile
+# Usefull for updating that container and uploading it
+# to our AWS Docker Container Repository
+#
+# EX: ./run_docker_build_node.sh
+#######################################################
+set -e
+
+BOX_NAME="materia-fake-s3"
+DOCKERFILE="dockerfiles/materia-fakes3"
+DCR="ucfopen"
+
+docker build -t $BOX_NAME:latest -f $DOCKERFILE .
+
+echo "==================================================="
+echo "To tag the latest build as a specific version, use:"
+echo "> docker tag $BOX_NAME:latest $DCR/$BOX_NAME:latest"
+echo "or"
+echo "> docker tag $BOX_NAME:latest $DCR/$BOX_NAME:X.X.X"
+echo "To publish the 'latest' container:"
+echo "> docker push $DCR/$BOX_NAME:latest"
+echo "or"
+echo "> docker push $DCR/$BOX_NAME:X.X.X"

--- a/run_first.sh
+++ b/run_first.sh
@@ -30,10 +30,6 @@ if [ ! -d app ]; then
 	git clone https://github.com/ucfcdl/Materia.git app
 fi
 
-if [ ! -d materia-thumbnail-generator ]; then
-	git clone https://clu.cdl.ucf.edu/serverless/materia-thumbnail-generator.git
-fi
-
 if [ ! -d app ]; then
 	echo "It looks like the app directory is empty"
 	exit

--- a/run_first.sh
+++ b/run_first.sh
@@ -53,8 +53,13 @@ if [ -f  app/fuel/app/config/development/migrations.php ]; then
 	rm -f app/fuel/app/config/development/migrations.php
 fi
 
+# setup mysql
 docker-compose run --rm phpfpm /wait-for-it.sh mysql:3306 -t 20 -- composer oil-install-quiet
 
+# install all the configured widgets
+docker-compose run --rm phpfpm bash -c 'php oil r widget:install_from_config'
+
+# Install any widgets in the tmp dir
 docker-compose run --rm phpfpm bash -c 'php oil r widget:install fuel/app/tmp/widget_packages/*.wigt'
 
 source run_assets_build.sh


### PR DESCRIPTION
> Supports https://github.com/ucfcdl/Materia/pull/1160

* xsendfile and xaccell are no longer needed
* second server for static asssets is no longer needed - we'll defer optimization to a cdn
* fakes3 needs to be linked to the phpfpm container for writing to s3
* fakes3 is updated to v 2.0.0 which includes our custom script requirments
* fakes3 image greatly simplified, going from 400+mb to 50mb
* removes need for materia-thumbnail-generator code
